### PR TITLE
Reparación y actualización de links rotos: Error 404

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,18 +15,18 @@ En #ODSL estamos armando un inventario de datos públicos abiertos para que toda
 
 * `Chile <http://datos.gob.cl/>`_
 * `Uruguay‌ <http://datos.gub.uy/>`_
-* `Brasil‌ <http://dados.gov.br/‌>`_
+* `Brasil‌ <http://dados.gov.br>`_
 * `‌Paraguay‌ <https://www.datos.gov.py/>`_
-* `‌Bolivia‌ <https://datos.gob.bo/‌>`_
-* `Perú‌ <https://www.datosabiertos.gob.pe/‌‌>`_
+* `‌Bolivia‌ <https://datos.gob.bo>`_
+* `Perú‌ <https://www.datosabiertos.gob.pe>`_
 * `Ecuador‌ <http://www.datosabiertos.gob.ec/>`_
 * `‌Colombia‌ <https://www.datos.gov.co/>`_
 * `‌Venezuela‌ <http://datos.gob.ve/>`_
-* `Panamá‌ <https://www.datosabiertos.gob.pa/‌>`_
+* `Panamá‌ <https://www.datosabiertos.gob.pa>`_
 * `Costa‌ ‌Rica‌ <http://datosabiertos.presidencia.go.cr/home>`_
 * `El‌ ‌Salvador‌ <https://datos.gob.sv/>`_
 * `‌República‌ ‌Dominicana‌ <http://datos.gob.do/>`_
-* `Puerto‌ ‌Rico‌ <https://data.pr.gov/‌>`_
+* `Puerto‌ ‌Rico‌ <https://data.pr.gov>`_
 * `‌México‌ <https://datos.gob.mx‌>`_
 * `‌Chicago‌ (EEUU) <https://data.cityofchicago.org>`_
 
@@ -38,11 +38,11 @@ En #ODSL estamos armando un inventario de datos públicos abiertos para que toda
 * `Ministerio de Hacienda <https://www.minhacienda.gob.ar/datos/>`_
 * `Ministerio de Modernización Presidencia de la Nación <http://datos.gob.ar>`_
 * `Ministerio de Transporte <https://servicios.transporte.gob.ar/gobierno_abierto/>`_
-* `Min. Relaciones Exteriores y Culto <https://www.cancilleria.gob.ar/es/iniciativas/datos-abiertos‌>`_
-* `‌Justicia Argentina <http://datos.jus.gob.ar/‌‌>`_
-* `Admin. Nac. de la Seguridad Social <https://www.anses.gob.ar/institucional/datos-abiertos‌>`_
-* `Ente de Nacional de Telecomunicaciones <https://datosabiertos.enacom.gob.ar/home‌‌>`_
-* `Corte Suprema de la Nación <https://datos.csjn.gov.ar/organization/csjn‌>`_
+* `Min. Relaciones Exteriores y Culto <https://www.cancilleria.gob.ar/es/iniciativas/datos-abiertos>`_
+* `‌Justicia Argentina <http://datos.jus.gob.ar>`_
+* `Admin. Nac. de la Seguridad Social <https://www.anses.gob.ar/institucional/datos-abiertos>`_
+* `Ente de Nacional de Telecomunicaciones <https://datosabiertos.enacom.gob.ar/home/>`_
+* `Corte Suprema de la Nación <https://datos.csjn.gov.ar/dataset>`_
 
 📌 Provincia / Ciudades
 -----------------------
@@ -50,29 +50,29 @@ En #ODSL estamos armando un inventario de datos públicos abiertos para que toda
 * `Provincia de Buenos Aires <https://catalogo.datos.gba.gob.ar/‌>`_
 * `Ciudad de Buenos Aires <https://data.buenosaires.gob.ar/>`_ ‌
 * `Ciudad‌ ‌de Rosario‌ <https://datos.rosario.gob.ar/‌>`_ ‌
-* `Ciudad‌ ‌de‌ ‌Córdoba‌ <https://gobiernoabierto.cordoba.gob.ar/data/datos-abiertos‌>`_
-* `Gobierno de Mendoza <http://datosabiertos.mendoza.gov.ar/‌>`_
-* `Gobierno de Misiones <http://www.datos.misiones.gov.ar/‌>`_
-* `‌Gobierno‌ ‌de‌ ‌Jujuy <http://datos.gajujuy.gob.ar/‌>`_ 
-* `‌Gobierno‌ ‌de‌ Santa Fe <https://www.santafe.gob.ar/datosabiertos/‌>`_ 
-* `‌Gobierno‌ ‌de‌ Entre Rios <https://www.entrerios.gov.ar/gobiernoabierto/‌>`_
+* `Ciudad‌ ‌de‌ ‌Córdoba‌ <https://gobiernoabierto.cordoba.gob.ar/>`_
+* `Gobierno de Mendoza <http://datosabiertos.mendoza.gov.ar>`_
+* `Gobierno de Misiones <http://www.datos.misiones.gov.ar>`_
+* `‌Gobierno‌ ‌de‌ ‌Jujuy <http://datos.gajujuy.gob.ar>`_ 
+* `‌Gobierno‌ ‌de‌ Santa Fe <https://www.santafe.gob.ar/datosabiertos/>`_ 
+* `‌Gobierno‌ ‌de‌ Entre Rios <https://www.entrerios.gov.ar/gobiernoabierto/index.php>`_
 * `Gobierno‌ ‌de‌ ‌Formosa‌ <https://www.formosa.gob.ar/datosabiertos>`_
 * `Gobierno‌ ‌de‌ Tucumán‌ <http://datos.tucuman.gov.ar/>`_
 * `Gobierno‌ ‌de‌ La Rioja <https://web.larioja.org/dato-abierto>`_
 * `Gobierno‌ ‌de‌ Catamarca‌ <https://www.catamarcaciudad.gob.ar/datos-abiertos/>`_
 * `Gobierno‌ ‌de‌ San Juan <https://www.datosabiertos.sanjuan.gob.ar/>`_
 * `Gobierno‌ ‌de‌ Neuquén‌ <https://portaldatos.neuquen.gov.ar/>`_
-* `Gobierno‌ ‌de‌ San Luis <https://www.ciudaddesanluis.gov.ar/>`_
+* `Gobierno‌ ‌de‌ San Luis <http://www.estadistica.sanluis.gov.ar/>`_
 * `Gobierno‌ ‌de‌ Chubut‌ <http://datos.chubut.gov.ar/>`_
-* `Gobierno‌ ‌de‌ Rio Negro‌ <https://www.rionegro.gov.co/Transparencia/Paginas/Datos-Abiertos‌.aspx‌/>`_
-* `Poder‌ ‌Judicial‌ ‌de‌ ‌Río‌ ‌Negro‌ <http://servicios.jusrionegro.gov.ar/inicio/web/gobierno-abierto/esta‌disticas/index.php‌/>`_
+* `Gobierno‌ ‌de‌ Rio Negro‌ <https://rionegro.gov.co/transparencia/>`_
+* `Poder‌ ‌Judicial‌ ‌de‌ ‌Río‌ ‌Negro‌ <http://servicios.jusrionegro.gov.ar/inicio/web/gobierno-abierto/estadisticas/index.php>`_
 * `Gobierno‌ de ‌Tierra‌ ‌del‌ ‌Fuego‌ <https://gestiontransparente.tierradelfuego.gob.ar/tdf-data-2/>`_
 
 
 📌 Entidades y Empresas
 -----------------------
 
-* `Techo‌ <http://datos.techo.org/fa_IR/‌>`_
+* `Techo‌ <http://datos.techo.org/dataset>`_
 * `Banco Mundial <https://datos.bancomundial.org/>`_
 * `ARSAT‌ ‌Empresa Argentina de Soluciones Satelitales Sociedad Anónima <https://datos.arsat.com.ar/home>`_
 * `Datos sobre educación‌ ‌(Luminis) <https://www.fundacionluminis.org.ar/datos-abiertos-educacion>`_


### PR DESCRIPTION
## Buenas noches. Mi nombre es Carlos Bustillo.

Detecte links rotos con Error 404 debido a cambio de URL o porque han sido dado de baja. 
Corregí algunos y los demás los actualice a la URL donde se encuentran actualmente en internet.

